### PR TITLE
Export extra variables from module for use in fargate cron jobs

### DIFF
--- a/output.tf
+++ b/output.tf
@@ -2,3 +2,13 @@ output "task_definition_arn" {
   value       = aws_ecs_task_definition.main_task.arn
   description = "The arn of your task definition"
 }
+
+output "task_definition_family" {
+  value       = aws_ecs_task_definition.main_task.family
+  description = "The family of your task definition"
+}
+
+output "task_definition_revision" {
+  value       = aws_ecs_task_definition.main_task.revision
+  description = "The revision of your task definition"
+}


### PR DESCRIPTION
We're exposing two variables needed to terraform a cloudwatch rule to run a cron job.